### PR TITLE
Fixed misbehaviour of generated UIImage with UIViewContentModeScaleAspectFit

### DIFF
--- a/QRCode/Source/QRCode.swift
+++ b/QRCode/Source/QRCode.swift
@@ -102,7 +102,12 @@ open class QRCode: NSObject, AVCaptureMetadataOutputObjectsDelegate {
         let transform = CGAffineTransform(scaleX: 10, y: 10)
         let transformedImage = qrFilter.outputImage!.applying(transform)
         
-        let image = UIImage(ciImage: transformedImage)
+        let context = CIContext(options: nil)
+        guard let cgImage = context.createCGImage(transformedImage, from: transformedImage.extent) else {
+            return nil
+        }
+        
+        let image = UIImage(cgImage: cgImage)
         
         if avatarImage != nil {
             return insertAvatarImage(image, avatarImage: avatarImage!, scale: avatarScale)


### PR DESCRIPTION
Fix Bug: when I use function generateImage with avatarImage nil, then I use UIImagePNGRepresentation from image result it return nil. 
Reference from this: https://github.com/aschuch/QRCode/commit/5d026ab136ec09868981a14c3ee8618e33b2692d